### PR TITLE
feat: использовании более светлого варианта светло-синего текста

### DIFF
--- a/src/components/menu/AccountManager.vue
+++ b/src/components/menu/AccountManager.vue
@@ -189,6 +189,6 @@ export default {
 }
 
 .account_user.add-profile .account_user_name {
-  color: var(--text-light-blue);
+  color: var(--text-blue);
 }
 </style>

--- a/src/components/messages/MessagesChatViewer.vue
+++ b/src/components/messages/MessagesChatViewer.vue
@@ -63,7 +63,7 @@ export default {
 
 .im_chat_viewer_title {
   padding-left: 10px;
-  color: var(--text-light-blue);
+  color: var(--text-blue);
 }
 
 /* Здесь снимается ограничение на ширину сообщения, потому что здесь */

--- a/src/components/messages/chat/Input.vue
+++ b/src/components/messages/chat/Input.vue
@@ -362,7 +362,7 @@ export default {
 }
 
 .chat_input_error.isChannel {
-  color: var(--text-light-blue);
+  color: var(--text-blue);
   cursor: pointer;
   transition: background-color .2s;
 }

--- a/src/components/messages/chat/Keyboard.vue
+++ b/src/components/messages/chat/Keyboard.vue
@@ -274,7 +274,7 @@ export default {
 }
 
 .keyboard_service_key {
-  color: var(--text-light-blue);
+  color: var(--text-blue);
 }
 
 .keyboard_services_icon {

--- a/src/components/messages/chat/attachments/Attachments.vue
+++ b/src/components/messages/chat/attachments/Attachments.vue
@@ -137,7 +137,7 @@ export default {
 }
 
 .outline_button {
-  color: var(--text-light-blue);
+  color: var(--text-blue);
   border: 1px solid var(--accent);
   border-radius: 8px;
   padding: 3px 16px;

--- a/src/css/colors.css
+++ b/src/css/colors.css
@@ -20,8 +20,7 @@
   --text-steel-gray: #6d7885;
   --text-dark-steel-gray: #5c6570;
   --text-gray: #454647;
-  --text-blue: #2a5989;
-  --text-light-blue: #0f5cb3;
+  --text-blue: #0f5cb3;
 
   --accent: #528bcc;
   --red: #de3f3f;


### PR DESCRIPTION
При переходе на Electron 10 у текста на Windows появился субпиксельный 
антиалиасинг, который сделал текст более четким, но в то же время сделал 
цвет текста немного более темным